### PR TITLE
Add XamlCSS classes to global WPF xml namespace for cleaner syntax

### DIFF
--- a/XamlCSS.Tests/CssParsing/CssNamespaceTests.cs
+++ b/XamlCSS.Tests/CssParsing/CssNamespaceTests.cs
@@ -40,7 +40,7 @@ namespace XamlCSS.Tests.CssParsing
         [Test]
         public void ClrNamespace_should_be_translated_to_qualifiednamespace()
         {
-            TypeHelpers.Initialze(new Dictionary<string, List<string>>{
+            TypeHelpers.Initialize(new Dictionary<string, List<string>>{
                 { 
                     "http://schemas.microsoft.com/winfx/2006/xaml/presentation",
                     new List<string>

--- a/XamlCSS.WPF.TestApp/App.xaml
+++ b/XamlCSS.WPF.TestApp/App.xaml
@@ -1,43 +1,42 @@
-﻿<Application x:Class="XamlCSS.WPF.TestApp.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:XamlCSS.WPF.TestApp"
-			 xmlns:sys="clr-namespace:System;assembly=mscorlib"
-             xmlns:css="clr-namespace:XamlCSS;assembly=XamlCSS"
-             StartupUri="MainWindow.xaml">
+﻿<Application
+    x:Class="XamlCSS.WPF.TestApp.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:XamlCSS.WPF.TestApp"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib"
+    StartupUri="MainWindow.xaml">
     <Application.Resources>
         <local:StringToImageConverter x:Key="StringToImageConverter" />
         <sys:String x:Key="AppStaticResource">App Static Resource</sys:String>
         <sys:String x:Key="testString">Hello World from StaticResource!</sys:String>
-        <css:StyleSheet x:Key="appStyleSheet">
-            <css:StyleSheet.Content>
-                Button
+        <StyleSheet x:Key="appStyleSheet">
+            Button
             {
-                FontStyle: Italic;
+            FontStyle: Italic;
             }
-            </css:StyleSheet.Content>
-        </css:StyleSheet>
+        </StyleSheet>
 
-        <local:ListToStringConverter x:Key="ListToStringConverter"></local:ListToStringConverter>
+        <local:ListToStringConverter x:Key="ListToStringConverter" />
         <Brush x:Key="ToColor">#00aa00</Brush>
         <Storyboard x:Key="storyboard">
-            <ColorAnimation 
-						Storyboard.TargetProperty="(TextBlock.Background).(SolidColorBrush.Color)" 
-                    To="Red" Duration="0:0:3" >
-            </ColorAnimation>
+            <ColorAnimation
+                Storyboard.TargetProperty="(TextBlock.Background).(SolidColorBrush.Color)"
+                To="Red"
+                Duration="0:0:3" />
         </Storyboard>
-        <ControlTemplate x:Key="abc" TargetType="Button">            
+        <ControlTemplate x:Key="abc" TargetType="Button">
             <Border Background="{TemplateBinding Background}">
                 <ContentPresenter />
             </Border>
         </ControlTemplate>
         <Storyboard x:Key="storyboard2">
-            <ColorAnimation 
-						Storyboard.TargetProperty="(TextBlock.Background).(SolidColorBrush.Color)" To="Green" Duration="0:0:5.25" >
-            </ColorAnimation>
+            <ColorAnimation
+                Storyboard.TargetProperty="(TextBlock.Background).(SolidColorBrush.Color)"
+                To="Green"
+                Duration="0:0:5.25" />
         </Storyboard>
-        <css:StyleSheet x:Key="InternalStyle" xml:space="preserve">
-                <css:StyleSheet.Content><![CDATA[
+        <StyleSheet x:Key="InternalStyle" xml:space="preserve">
+<![CDATA[
 // @import "appStyleSheet";
 // @import "Resources/baseStyle.scss";
 @namespace animation "System.Windows.Media.Animation, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
@@ -186,7 +185,6 @@ Grid
         }
     }
 }]]>
-                </css:StyleSheet.Content>
-            </css:StyleSheet>
+        </StyleSheet>
     </Application.Resources>
 </Application>

--- a/XamlCSS.WPF.TestApp/MainWindow.xaml
+++ b/XamlCSS.WPF.TestApp/MainWindow.xaml
@@ -6,15 +6,13 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:XamlCSS.WPF.TestApp"
-        xmlns:css="clr-namespace:XamlCSS;assembly=XamlCSS"
-		xmlns:cssWPF="clr-namespace:XamlCSS.WPF;assembly=XamlCSS.WPF"
 		xmlns:sys="clr-namespace:System;assembly=mscorlib"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance local:MainWindowViewModel, IsDesignTimeCreatable=True}"
-        cssWPF:Css.Class="main light"
+        Css.Class="main light"
         Title="MainWindow" Height="350" Width="525"
     xmlns:conv="clr-namespace:XamlCSS.WPF.TestApp.Converters"
-          cssWPF:Css.StyleSheet="{DynamicResource InternalStyle}">
+          Css.StyleSheet="{DynamicResource InternalStyle}">
     <!--<StackPanel>
         <Button Click="Button_Click_3">css</Button>
         <Button x:Name="buttonCss3" Click="Button_Click_3">css</Button>
@@ -27,8 +25,8 @@
             <DataTemplate
                  xmlns:cssWPF="clr-namespace:XamlCSS.WPF;assembly=XamlCSS.WPF">
                 <StackPanel>
-                    <StackPanel cssWPF:Css.Class="uuu">
-                        <Label cssWPF:Css.Class="aaa">a</Label>
+                    <StackPanel Css.Class="uuu">
+                        <Label Css.Class="aaa">a</Label>
                     </StackPanel>
                 </StackPanel>
             </DataTemplate>
@@ -46,8 +44,8 @@
     <Grid x:Name="thegrid"
           >
         <StackPanel x:Name="stack">
-            <StackPanel cssWPF:Css.Class="container">
-                <TextBlock Name="thetextblock" cssWPF:Css.Class="jumbo">Hello World</TextBlock>
+            <StackPanel Css.Class="container">
+                <TextBlock Name="thetextblock" Css.Class="jumbo">Hello World</TextBlock>
                 <Button Click="Button_Click_1">Add Content</Button>
             </StackPanel>
             <Grid>
@@ -65,10 +63,10 @@
             </Grid>
             <Button Click="Button_Click_2">Click me</Button>
 
-            <StackPanel Orientation="Horizontal" cssWPF:Css.Class="important-button-container">
+            <StackPanel Orientation="Horizontal" Css.Class="important-button-container">
                 <Button x:Name="buttonCss3" Click="Button_Click_3">
                     <TextBlock Name="textBox1">
-                        <Run x:Name="runCss3" cssWPF:Css.Class="fa fa-css3"></Run>
+                        <Run x:Name="runCss3" Css.Class="fa fa-css3"></Run>
                         <Run>Open live Style Editor</Run>
                     </TextBlock>
                 </Button>
@@ -92,8 +90,8 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <StackPanel>
-                            <StackPanel cssWPF:Css.Class="uuu">
-                                <Label cssWPF:Css.Class="aaa">a</Label>
+                            <StackPanel Css.Class="uuu">
+                                <Label Css.Class="aaa">a</Label>
                             </StackPanel>
                         </StackPanel>
                     </DataTemplate>
@@ -106,25 +104,25 @@
 
             <ItemsControl
 				x:Name="test" 
-                cssWPF:Css.Class="menu-items" 
+                Css.Class="menu-items" 
                 ItemsSource="{Binding MenuItems}"
                 MinHeight="10"
 					  >
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Button Template="{StaticResource ContainerButton}">
-                            <StackPanel cssWPF:Css.Class="menu-item-container">
-                                <DockPanel cssWPF:Css.Class="menu-item">
+                            <StackPanel Css.Class="menu-item-container">
+                                <DockPanel Css.Class="menu-item">
                                     <Button Template="{StaticResource ContainerButton}">
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock TextAlignment="Center" HorizontalAlignment="Center" VerticalAlignment="Center" cssWPF:Css.Class="fa" Text="{Binding Icon}" />
+                                            <TextBlock TextAlignment="Center" HorizontalAlignment="Center" VerticalAlignment="Center" Css.Class="fa" Text="{Binding Icon}" />
                                             <TextBlock Text="{Binding Text}" />
                                         </StackPanel>
                                     </Button>
 
                                     
                                 </DockPanel>
-                                <ItemsControl cssWPF:Css.Class="sub-menu-item" ItemsSource="{Binding SubMenuItems}" Visibility="{Binding IsSubMenuVisible, Converter={StaticResource VisibilityConverter}}">
+                                <ItemsControl Css.Class="sub-menu-item" ItemsSource="{Binding SubMenuItems}" Visibility="{Binding IsSubMenuVisible, Converter={StaticResource VisibilityConverter}}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <StackPanel>
@@ -151,18 +149,18 @@
                     <FlowDocumentScrollViewer>
                         <FlowDocument>
                             <Paragraph>
-                                <Run cssWPF:Css.Class="header" Text="asdfasdfasdf"></Run>
+                                <Run Css.Class="header" Text="asdfasdfasdf"></Run>
                             </Paragraph>
 
                             <Paragraph>
                                 <Run Text="asdfasdfadsf"></Run>
                             </Paragraph>
-                            <List cssWPF:Css.Class="list">
+                            <List Css.Class="list">
                                 <ListItem>
                                     <Paragraph>
-                                        <Run cssWPF:Css.Class="fa fa-graduation-cap"></Run> &#160;
+                                        <Run Css.Class="fa fa-graduation-cap"></Run> &#160;
                                         <Hyperlink NavigateUri="https://aka.ms/willowlearn" >
-                                            <Run cssWPF:Css.Class="subheader important" Text="asdfasdfasdf"></Run>
+                                            <Run Css.Class="subheader important" Text="asdfasdfasdf"></Run>
                                         </Hyperlink>
                                     </Paragraph>
                                     <Paragraph Margin="21,10,0,0">
@@ -171,12 +169,12 @@
                                 </ListItem>
                             </List>
 
-                            <List cssWPF:Css.Class="list">
+                            <List Css.Class="list">
                                 <ListItem>
                                     <Paragraph>
-                                        <Run cssWPF:Css.Class="fa fa-shoping-bag"></Run> &#160;
+                                        <Run Css.Class="fa fa-shoping-bag"></Run> &#160;
                                         <Hyperlink NavigateUri="https://aka.ms/willowmarketplace" >
-                                            <Run cssWPF:Css.Class="subheader important" Text="asdfasdfasfd"></Run>
+                                            <Run Css.Class="subheader important" Text="asdfasdfasfd"></Run>
                                         </Hyperlink>
                                     </Paragraph>
                                     <Paragraph Margin="21,10,0,0">
@@ -185,7 +183,7 @@
                                 </ListItem>
                             </List>
                             <Paragraph  Margin="0,21,0,5">
-                                <Run cssWPF:Css.Class="subheader" Text="asdfasdfasf"></Run>
+                                <Run Css.Class="subheader" Text="asdfasdfasf"></Run>
                             </Paragraph>
                             <Paragraph  Margin="0,0,0,0">
                                 <Run Text="asdfasdfasdf"></Run>

--- a/XamlCSS.WPF.TestApp/XamlCSS.WPF.TestApp.csproj
+++ b/XamlCSS.WPF.TestApp/XamlCSS.WPF.TestApp.csproj
@@ -124,7 +124,7 @@
       <Name>XamlCSS.WPF</Name>
     </ProjectReference>
     <ProjectReference Include="..\XamlCSS\XamlCSS.csproj">
-      <Project>{67f9d3a8-f71e-4428-913f-c37ae82cdb24}</Project>
+      <Project>{a11ea228-bcdc-46ec-8f8b-57fc9227c1ac}</Project>
       <Name>XamlCSS</Name>
     </ProjectReference>
   </ItemGroup>

--- a/XamlCSS.WPF.Tests/ResolveTypeTests.cs
+++ b/XamlCSS.WPF.Tests/ResolveTypeTests.cs
@@ -31,7 +31,7 @@ namespace XamlCSS.WPF.Tests
                 }
             };
 
-            TypeHelpers.Initialze(mapping, true);
+            TypeHelpers.Initialize(mapping, true);
         }
 
         [Test]

--- a/XamlCSS.WPF.Tests/StyleSheetTests.cs
+++ b/XamlCSS.WPF.Tests/StyleSheetTests.cs
@@ -28,7 +28,7 @@ namespace XamlCSS.Tests.CssParsing
                 }
             };
 
-            TypeHelpers.Initialze(mapping);
+            TypeHelpers.Initialize(mapping);
 
             CssParser.Initialize(typeof(System.Windows.Controls.Button).AssemblyQualifiedName.Replace(".Button,", ","), null);
 

--- a/XamlCSS.WPF/Css.cs
+++ b/XamlCSS.WPF/Css.cs
@@ -63,7 +63,7 @@ namespace XamlCSS.WPF
 
             cssNamespaceMapping = cssNamespaceMapping ?? DefaultCssNamespaceMapping;
 
-            TypeHelpers.Initialze(cssNamespaceMapping);
+            TypeHelpers.Initialize(cssNamespaceMapping);
 
             var defaultCssNamespace = cssNamespaceMapping.Keys.First();
             var dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;

--- a/XamlCSS.WPF/Properties/AssemblyInfo.cs
+++ b/XamlCSS.WPF/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Windows.Markup;
 
 // Allgemeine Informationen über eine Assembly werden über die folgenden 
 // Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
@@ -23,3 +24,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation", "XamlCSS.WPF")]

--- a/XamlCSS.WPF/XamlCSS.WPF.csproj
+++ b/XamlCSS.WPF/XamlCSS.WPF.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net451;net461;net471</TargetFrameworks>
 		<ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
@@ -8,8 +8,8 @@
         <Company />
         <Copyright>David Rettenbacher</Copyright>
         <PackageProjectUrl>https://github.com/warappa/XamlCSS</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/warappa/XamlCSS/blob/master/LICENSE</PackageLicenseUrl>
-        <PackageIconUrl>https://github.com/warappa/XamlCSS/blob/master/Content/Logo.jpg</PackageIconUrl>
+        <License>https://github.com/warappa/XamlCSS/blob/master/LICENSE</License>
+        <Icon>https://github.com/warappa/XamlCSS/blob/master/Content/Logo.jpg</Icon>
         <RepositoryUrl>https://github.com/warappa/XamlCSS</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>xamlcss xaml css wpf</PackageTags>

--- a/XamlCSS.XamarinForms/Css.cs
+++ b/XamlCSS.XamarinForms/Css.cs
@@ -84,7 +84,7 @@ namespace XamlCSS.XamarinForms
 
                 cssNamespaceMapping = cssNamespaceMapping ?? DefaultCssNamespaceMapping;
 
-                TypeHelpers.Initialze(cssNamespaceMapping, true);
+                TypeHelpers.Initialize(cssNamespaceMapping, true);
 
                 var defaultCssNamespace = cssNamespaceMapping.Keys.First();
                 var markupExtensionParser = new MarkupExtensionParser();

--- a/XamlCSS/Properties/AssemblyInfo.cs
+++ b/XamlCSS/Properties/AssemblyInfo.cs
@@ -2,6 +2,9 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#if NET451 || NET461
+using System.Windows.Markup;
+#endif
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -23,3 +26,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("XamlCSS.UWP")]
 [assembly: InternalsVisibleTo("XamlCSS.WPF")]
 [assembly: InternalsVisibleTo("XamlCSS.XamarinForms")]
+
+#if NET451 || NET461
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation", "XamlCSS")]
+#endif

--- a/XamlCSS/StyleSheet.cs
+++ b/XamlCSS/StyleSheet.cs
@@ -10,6 +10,9 @@ using XamlCSS.Utils;
 
 namespace XamlCSS
 {
+#if NET451 || NET461
+    [System.Windows.Markup.ContentProperty(nameof(Content))]
+#endif
     public class StyleSheet : INotifyPropertyChanged
     {
         public static readonly StyleSheet Empty = new StyleSheet();

--- a/XamlCSS/Utils/Investigate.cs
+++ b/XamlCSS/Utils/Investigate.cs
@@ -24,8 +24,9 @@ namespace XamlCSS.Utils
 #if !INVESTIGATE
             action();
             return;
-#endif
+#else
             title.Measure(() => { action(); return true; });
+#endif
         }
 
         [DebuggerStepThrough]

--- a/XamlCSS/Utils/TypeHelpers.cs
+++ b/XamlCSS/Utils/TypeHelpers.cs
@@ -11,7 +11,7 @@ namespace XamlCSS.Utils
         private static bool dependencyPropertiesAreFields = true;
         private static IDictionary<string, List<string>> namespaceMapping = new Dictionary<string, List<string>>();
 
-        public static void Initialze(IDictionary<string, List<string>> namespaceMapping, bool dependencyPropertiesAreFields = true)
+        public static void Initialize(IDictionary<string, List<string>> namespaceMapping, bool dependencyPropertiesAreFields = true)
         {
             TypeHelpers.namespaceMapping = namespaceMapping;
             TypeHelpers.dependencyPropertiesAreFields = dependencyPropertiesAreFields;

--- a/XamlCSS/XamlCSS.csproj
+++ b/XamlCSS/XamlCSS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+<Project Sdk="MSBuild.Sdk.Extras">
     <!--<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(TargetPlatformIdentifier)' == 'UAP' AND Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />-->
     
     <PropertyGroup>
@@ -8,8 +8,8 @@
         <Company />
         <Copyright>David Rettenbacher</Copyright>
         <PackageProjectUrl>https://github.com/warappa/XamlCSS</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/warappa/XamlCSS/blob/master/LICENSE</PackageLicenseUrl>
-        <PackageIconUrl>https://github.com/warappa/XamlCSS/blob/master/Content/Logo.jpg</PackageIconUrl>
+        <License>https://github.com/warappa/XamlCSS/blob/master/LICENSE</License>
+        <Icon>https://github.com/warappa/XamlCSS/blob/master/Content/Logo.jpg</Icon>
         <RepositoryUrl>https://github.com/warappa/XamlCSS</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>xamlcss xaml css wpf xamarin.forms uwp</PackageTags>
@@ -145,6 +145,10 @@
         <Description>Style XAML applications with CSS</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net461'">
+      <Reference Include="System.Xaml"/>
+    </ItemGroup>
+
     <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
         <!--<TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
         <OutputPath>bin\Debug\</OutputPath>


### PR DESCRIPTION
Hi, I recently discovered your project and I really like it!
I wondered if it wouldn't be cleaner to include the namespaces in the global one, this allows to use (amongst others) the Css class and its attached properties, without using the xmlns prefix all the time (which can be too clumsy IMO).

I added the System.Windows.Markup.ContentProperty attribute which allows not to explicitely put the StyleSheet.Content tag.
Also there was a typo with the "Initialize" method missing the last "i", I fixed this.
Also VS2019 complained about obsolete tags in csproj files (license and icon url) so I fixed it too.
Feel free to just take these little bits and ignore the global tag thing. I thought it could be nice, maybe make an issue about it?
Cheers and nice project!